### PR TITLE
Removing calls to "Poll All" on chargers

### DIFF
--- a/drivers/charger/device.js
+++ b/drivers/charger/device.js
@@ -12,7 +12,6 @@ class ChargerDevice extends Homey.Device {
         this.log(`Easee charger initiated, '${this.getName()}'`);
 
         this.pollIntervals = [];
-        this.refresh_status_charger = this.getSettings().refresh_status_charger || 5;
         this.refresh_status_cloud = this.getSettings().refresh_status_cloud || 10;
 
         this.charger = {
@@ -193,14 +192,6 @@ class ChargerDevice extends Homey.Device {
             });
     }
 
-    refreshChargerObservations() {
-        let self = this;
-        self.charger.api.refreshChargerObservations(self.charger.id)
-            .catch(reason => {
-                self.error(reason);
-            });
-    }
-
     pauseCharging() {
         return this.charger.api.pauseCharging(this.charger.id)
             .then(function (result) {
@@ -268,10 +259,6 @@ class ChargerDevice extends Homey.Device {
 
     _initilializeTimers() {
         this.log('Adding timers');
-        // Request charger to push update to cloud
-        this.pollIntervals.push(setInterval(() => {
-            this.refreshChargerObservations();
-        }, 60 * 1000 * this.refresh_status_charger));
 
         //Get updates from cloud
         this.pollIntervals.push(setInterval(() => {
@@ -337,11 +324,6 @@ class ChargerDevice extends Homey.Device {
 
     async onSettings(oldSettings, newSettings, changedKeysArr) {
         let change = false;
-        if (changedKeysArr.indexOf("refresh_status_charger") > -1) {
-            this.log('Refresh charger value was change to:', newSettings.refresh_status_charger);
-            this.refresh_status_charger = newSettings.refresh_status_charger;
-            change = true;
-        }
 
         if (changedKeysArr.indexOf("refresh_status_cloud") > -1) {
             this.log('Refresh cloud value was change to:', newSettings.refresh_status_cloud);

--- a/lib/easee.js
+++ b/lib/easee.js
@@ -84,18 +84,6 @@ EaseeCharger.prototype.toggleCharging = function (chargerId) {
         });
 }
 
-EaseeCharger.prototype.refreshChargerObservations = function (chargerId) {
-    var self = this;
-    return postCommand(self.options, `/api/chargers/${chargerId}/commands/poll_all`)
-        .then(function (result) {
-            return result;
-        })
-        .catch(reason => {
-            self.emit(apiErrorEventName, reason);
-            return Promise.reject(reason);
-        });
-}
-
 EaseeCharger.prototype.setChargerState = function (chargerId, state) {
     var self = this;
     let data = {


### PR DESCRIPTION
Easee will be removing the ability to do "PollAll" on chargers directly, so i am submitting this PR as a suggestion to prevent users getting errors in the app on every refresh.

This step should not be needed to get an updated state from the cloud as the charger should push all relevant changes either on a timer, or on change.

If you feel like there is information missing in the state response that should be refreshed more frequently please feel free to contact me.

Best Regards,
Eirik Ottesen