### PR TITLE
Add flow cards for pausing and resuming charging sessions

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,4 +1,8 @@
 {
+    "1.8.6": {
+        "en": "Added flow cards for pausing and resuming charging sessions.",
+        "sv": "Lade till flödeskort för att pausa och återuppta laddningssessioner."
+    },
     "1.8.5": {
         "en": "Fix for dynamic circuit current",
         "sv": "Buggfix för dynamisk kretsström"

--- a/app.json
+++ b/app.json
@@ -945,6 +945,24 @@
         ]
       },
       {
+        "id": "pauseCharging",
+        "title": {
+          "en": "Pause Charging",
+          "sv": "Pausa laddning"
+        },
+        "titleFormatted": {
+          "en": "Pause Charging",
+          "sv": "Pausa laddning"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=charger"
+          }
+        ]
+      },
+      {
         "id": "pauseSmartCharging",
         "title": {
           "en": "Pause smart charging",
@@ -975,6 +993,24 @@
         "titleFormatted": {
           "en": "Reboot charger",
           "sv": "Starta om laddaren"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=charger"
+          }
+        ]
+      },
+      {
+        "id": "resumeCharging",
+        "title": {
+          "en": "Resume Charging",
+          "sv": "Återuppta laddning"
+        },
+        "titleFormatted": {
+          "en": "Resume Charging",
+          "sv": "Återuppta laddning"
         },
         "args": [
           {

--- a/drivers/charger/driver.js
+++ b/drivers/charger/driver.js
@@ -211,6 +211,24 @@ class ChargerDriver extends Homey.Driver {
                 });
         });
 
+        // Register flow card for pausing charging
+        const pauseCharging = this.homey.flow.getActionCard('pauseCharging');
+        pauseCharging.registerRunListener(async (args) => {
+            this.log(`[${args.device.getName()}] Action 'pauseCharging' triggered`);
+            return args.device.pauseCharging()
+                .then(() => Promise.resolve(true))
+                .catch(reason => Promise.reject(`Failed to pause charging. Reason: ${reason.message}`));
+        });
+
+        // Register flow card for resuming charging
+        const resumeCharging = this.homey.flow.getActionCard('resumeCharging');
+        resumeCharging.registerRunListener(async (args) => {
+            this.log(`[${args.device.getName()}] Action 'resumeCharging' triggered`);
+            return args.device.resumeCharging()
+                .then(() => Promise.resolve(true))
+                .catch(reason => Promise.reject(`Failed to resume charging. Reason: ${reason.message}`));
+        });
+
         //Deprecated
         const toggleCharger = this.homey.flow.getActionCard('toggleCharger');
         toggleCharger.registerRunListener(async (args) => {


### PR DESCRIPTION
This pull request introduces new features to the charging flow cards and updates the changelog accordingly. The most important changes include adding new flow cards for pausing and resuming charging sessions, and registering these actions in the charger driver.

These additions are based on the feature request in [#62 (closed)](https://github.com/homey-no.easee/issues/62), where it was noted that while pause/resume functionality already exists in the codebase, it was not accessible via flow cards. This meant users had to rely on the start/stop actions, which trigger re-authentication with the charger—a process that is not required when using pause/resume.

New Features:
* Added flow cards for pausing and resuming charging sessions in .homeychangelog.json.

Flow Card Additions:
* [`app.json`](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5R947-R964): Added a new flow card for pausing charging (pauseCharging) with the necessary arguments and titles in multiple languages.
* [`app.json`](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5R1005-R1022): Added a new flow card for resuming charging (resumeCharging) with the necessary arguments and titles in multiple languages.

Driver Updates:
* [`drivers/charger/driver.js`](diffhunk://#diff-830c2f83ee9aa189316200b297bfa077dca3d0702487d061ebbd735adce0a9f1R214-R231): Registered the new flow card actions for pausing (pauseCharging) and resuming (resumeCharging) charging sessions, including the corresponding run listeners.