### PR TITLE
Add surplus charging control for Equalizer devices

### DIFF
--- a/.homeycompose/flow/actions/disableSurplusCharging.json
+++ b/.homeycompose/flow/actions/disableSurplusCharging.json
@@ -1,0 +1,18 @@
+{
+    "id": "disableSurplusCharging",
+    "title": {
+        "en": "Disable surplus charging",
+        "sv": "Inaktivera överskottsladdning"
+    },
+    "titleFormatted": {
+        "en": "Disable surplus charging",
+        "sv": "Inaktivera överskottsladdning"
+    },
+    "args": [
+        {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=equalizer"
+        }
+    ]
+}

--- a/.homeycompose/flow/actions/enableSurplusCharging.json
+++ b/.homeycompose/flow/actions/enableSurplusCharging.json
@@ -1,0 +1,35 @@
+{
+    "id": "enableSurplusCharging",
+    "title": {
+        "en": "Enable surplus charging",
+        "sv": "Aktivera överskottsladdning"
+    },
+    "titleFormatted": {
+        "en": "Enable surplus charging with [[maxImportCurrent]] grid import",
+        "sv": "Aktivera överskottsladdning med [[maxImportCurrent]] nätimport"
+    },
+    "hint": {
+        "en": "Set to 0A for surplus only (no grid use). Set to 1-12A to allow limited grid import.",
+        "sv": "Sätt till 0A för endast överskott (ingen nätanvändning). Sätt till 1-12A för att tillåta begränsad nätimport."
+    },
+    "args": [
+        {
+            "name": "maxImportCurrent",
+            "type": "range",
+            "title": {
+                "en": "Maximum grid import current",
+                "sv": "Max nätimportström"
+            },
+            "min": 0,
+            "max": 12,
+            "step": 1,
+            "label": " A",
+            "labelDecimals": 0
+        },
+        {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=equalizer"
+        }
+    ]
+}

--- a/drivers/equalizer/driver.js
+++ b/drivers/equalizer/driver.js
@@ -59,6 +59,42 @@ class EqualizerDriver extends Homey.Driver {
                 return false;
             }
         });
+
+        //Actions
+        const disableSurplusCharging = this.homey.flow.getActionCard('disableSurplusCharging');
+        disableSurplusCharging.registerRunListener(async (args, state) => {
+            this.log(`[${args.device.getName()}] Action 'disableSurplusCharging' triggered`);
+            try {
+                await args.device.createEaseeChargerClient().disableSurplusCharging(args.device.getData().id);
+                this.log(`[${args.device.getName()}] Successfully disabled surplus charging`);
+                return true;
+            } catch (error) {
+                this.error(`[${args.device.getName()}] Failed to disable surplus charging:`, error);
+                throw new Error(`Failed to disable surplus charging: ${error.message}`);
+            }
+        });
+
+        const enableSurplusCharging = this.homey.flow.getActionCard('enableSurplusCharging');
+        enableSurplusCharging.registerRunListener(async (args, state) => {
+            this.log(`[${args.device.getName()}] Action 'enableSurplusCharging' triggered`);
+            this.log(`[${args.device.getName()}] maxImportCurrent: ${args.maxImportCurrent}A`);
+
+            // Validate input
+            const maxImportCurrent = Number(args.maxImportCurrent);
+            if (isNaN(maxImportCurrent) || maxImportCurrent < 0 || maxImportCurrent > 12) {
+                this.error(`[${args.device.getName()}] Invalid maxImportCurrent value: ${args.maxImportCurrent}`);
+                throw new Error('Maximum import current must be between 0 and 12 amps');
+            }
+
+            try {
+                await args.device.createEaseeChargerClient().enableSurplusCharging(args.device.getData().id, maxImportCurrent);
+                this.log(`[${args.device.getName()}] Successfully enabled surplus charging with ${maxImportCurrent}A max import`);
+                return true;
+            } catch (error) {
+                this.error(`[${args.device.getName()}] Failed to enable surplus charging:`, error);
+                throw new Error(`Failed to enable surplus charging: ${error.message}`);
+            }
+        });
     }
 
     async onPair(session) {

--- a/lib/Easee.js
+++ b/lib/Easee.js
@@ -382,6 +382,26 @@ class Easee {
         return await invoke(config.apiDomain, 'get', this, `/api/equalizers/${equalizerId}/config`);
     }
 
+    async getEqualizerSurplusConfig(equalizerId) {
+        return await invoke(config.apiDomain, 'get', this, `/cloud-loadbalancing/equalizer/${equalizerId}/config/surplus-energy`);
+    }
+
+    async disableSurplusCharging(equalizerId) {
+        return await this.#postWaitForResponse(`/cloud-loadbalancing/equalizer/${equalizerId}/config/surplus-energy`, {
+            mode: "none"
+        });
+    }
+
+    async enableSurplusCharging(equalizerId, maxImportCurrent) {
+        return await this.#postWaitForResponse(`/cloud-loadbalancing/equalizer/${equalizerId}/config/surplus-energy`, {
+            mode: "chargingWithImport",
+            chargingWithImport: {
+                eligible: true,
+                maximumImportAddedCurrent: maxImportCurrent
+            }
+        });
+    }
+
     async getLast30DaysChargekWh(chargerId) {
         let fromDate = new Date();
         fromDate.setDate(fromDate.getDate() - 30)


### PR DESCRIPTION
This PR implements two new flow actions for Easee Equalizer devices:

- **Equalizer - Disable surplus charging** - Disables surplus charging mode
- **Equalizer - Enable surplus charging** - Enables surplus charging with configurable grid import limit (0-12A)
  - 0A: Charges only with available surplus energy (no grid import)
  - 1-12A: Charges with surplus energy plus up to the specified grid import current

#### Note
The `getEqualizerSurplusConfig()` API method is implemented but not used. This could be utilized for showing the status in Homey, or for other flow cards.